### PR TITLE
correct nodejs define

### DIFF
--- a/src/db/mysql/MySqlDatabaseType.hx
+++ b/src/db/mysql/MySqlDatabaseType.hx
@@ -3,8 +3,8 @@ package db.mysql;
 import db.macros.IDatabaseType;
 import db.macros.DatabaseTypeInfo;
 
-#if (js && !(hxnodejs))
-#error "hxnodejs needed for js builds"
+#if (js && !(nodejs))
+#error "haxe nodejs lib needed for js builds"
 #end
 
 class MySqlDatabaseType implements IDatabaseType {


### PR DESCRIPTION
`hxnodejs` is the library name but the define the library specifies is `nodejs`